### PR TITLE
Changes to scraping due to untappd changes

### DIFF
--- a/.BeerGargoyle.toml.example
+++ b/.BeerGargoyle.toml.example
@@ -13,6 +13,33 @@ Port=51000
 [Integrations]
 Beer=["untappd_web"]
 
+[Integrations.Untappd]
+# Search is powered by Untappd's Algolia backend (not behind Cloudflare, no proxy
+# needed). These public search-only credentials default to the values embedded in
+# Untappd's web pages; override only if Untappd rotates them.
+AlgoliaAppID=""
+AlgoliaSearchKey=""
+AlgoliaBeerIndex="beer"
+AlgoliaBreweryIndex="brewery"
+
+# The proxy below is ONLY used to fetch beer/brewery descriptions when a beer is
+# saved. Those pages live on untappd.com (behind Cloudflare), which challenges
+# datacenter IPs (e.g. Fly.io). From residential IPs this works directly, so the
+# proxy can be left unset for local dev. Without a proxy in production, beers are
+# simply saved without a description.
+#
+# Generic proxy URL. Takes precedence over ScraperAPIKey. Set
+# ProxyInsecureSkipVerify=true if the proxy does TLS interception.
+# Recommended free option is Scrape.do's proxy mode (1,000 free calls/month, no
+# card, residential + Cloudflare bypass), e.g.:
+#   Proxy="http://YOUR_TOKEN:super=true&render=false@proxy.scrape.do:8080"
+#   ProxyInsecureSkipVerify=true
+Proxy=""
+ProxyInsecureSkipVerify=false
+# Alternatively, a ScraperAPI key (used only when Proxy is empty). Note ScraperAPI
+# no longer has a free tier — prefer Scrape.do above.
+ScraperAPIKey=""
+
 [Auth]
 SecretKey=""
 Audience=""

--- a/README.md
+++ b/README.md
@@ -1,3 +1,88 @@
 [![Go](https://github.com/sdroscher/BeerGargoyle-backend/actions/workflows/go.yml/badge.svg)](https://github.com/sdroscher/BeerGargoyle-backend/actions/workflows/go.yml)
 
 A beer cellar management backend API by Simon Droscher
+
+## Beer search (Untappd)
+
+Beer and brewery search are served by Untappd's **Algolia** search backend. The
+server queries Algolia's JSON API directly (`FindBeer` / `FindBrewery`), which:
+
+- returns structured data (name, brewery, ABV, IBU, style, rating, image), and
+- is **not** behind Cloudflare, so it works from any host (including Fly.io)
+  with no proxy.
+
+The public search-only Algolia credentials are embedded in Untappd's web pages
+and ship as defaults. If Untappd ever rotates them, override via config or env
+vars (no redeploy of code needed) — see `[Integrations.Untappd]` in
+`.BeerGargoyle.toml.example`:
+
+```bash
+fly secrets set BEERGARGOYLE_INTEGRATIONS_UNTAPPD_ALGOLIAAPPID=...
+fly secrets set BEERGARGOYLE_INTEGRATIONS_UNTAPPD_ALGOLIASEARCHKEY=...
+```
+
+## Beer descriptions — Cloudflare proxy setup
+
+Algolia search does **not** include the long beer/brewery descriptions — those
+live only on Untappd's individual beer/brewery pages, and the entire
+`untappd.com` domain is behind Cloudflare. Cloudflare serves a managed challenge
+(`cf-mitigated: challenge`, "Just a moment…") to **datacenter IPs** (such as
+Fly.io), so those pages can't be fetched directly from production. Residential
+IPs are not challenged, so this works without a proxy in local development.
+
+Descriptions are therefore fetched lazily and only **when a beer is saved**
+(server-side, in `AddBeer`) — one request per saved beer, not per search result.
+To make that work in production, route those detail-page fetches through a proxy
+with a clean (residential) IP, configured under `[Integrations.Untappd]`.
+
+If no proxy is configured, search and saving still work; the beer is just saved
+without a description when running from a blocked IP.
+
+### Option A — Scrape.do free tier (recommended)
+
+[Scrape.do](https://scrape.do) has a no-credit-card free tier of **1,000
+successful calls/month** including residential proxies and Cloudflare bypass —
+far more than save-time description fetches will ever use. It's used via its
+proxy-mode endpoint, so it plugs straight into the generic `Proxy` setting:
+
+```toml
+[Integrations.Untappd]
+Proxy = "http://YOUR_TOKEN:super=true&render=false@proxy.scrape.do:8080"
+ProxyInsecureSkipVerify = true
+```
+
+Or on Fly.io:
+
+```bash
+fly secrets set BEERGARGOYLE_INTEGRATIONS_UNTAPPD_PROXY='http://YOUR_TOKEN:super=true&render=false@proxy.scrape.do:8080'
+fly secrets set BEERGARGOYLE_INTEGRATIONS_UNTAPPD_PROXYINSECURESKIPVERIFY=true
+```
+
+- `super=true` → residential IP (untappd doesn't challenge residential IPs).
+- `render=false` → no JS rendering needed; the description is in the page's
+  server-rendered `ld+json`. If a request ever returns a challenge page, switch
+  to `render=true`.
+
+Other providers with free/cheap tiers work the same way via their proxy-mode
+URLs, e.g. ScrapingAnt (`proxy.scrapingant.com`) or pay-as-you-go residential
+proxies (IPRoyal, Bright Data) — cheap here because each page is ~150 KB.
+
+### Option B — Generic proxy
+
+Any HTTP proxy with a residential/ISP IP works (including a self-hosted proxy on
+a home connection):
+
+```toml
+[Integrations.Untappd]
+Proxy = "http://user:pass@host:port"
+# Set true only if the proxy performs TLS interception:
+ProxyInsecureSkipVerify = false
+```
+
+### ScraperAPI
+
+There is also a dedicated `ScraperAPIKey` setting (used only when `Proxy` is
+empty), but note ScraperAPI no longer offers a free tier — prefer Option A.
+
+`Proxy` takes precedence over `ScraperAPIKey`. Leave both unset to fetch
+descriptions directly (fine for local development from a residential connection).

--- a/configs/config.go
+++ b/configs/config.go
@@ -24,7 +24,50 @@ type Server struct {
 }
 
 type Integrations struct {
-	Beer []string `default:"untappd_web"`
+	Beer    []string `default:"untappd_web"`
+	Untappd Untappd
+}
+
+// Untappd configures the Untappd web-scraping beer search backend.
+type Untappd struct {
+	// Proxy is an optional outbound proxy for scraping requests, e.g.
+	// "http://user:pass@host:port". Cloudflare serves a managed challenge to
+	// datacenter IPs (such as Fly.io), so a residential/ISP proxy is required
+	// in production. Leave empty to scrape directly (works from residential
+	// IPs). Takes precedence over ScraperAPIKey.
+	Proxy string
+	// ScraperAPIKey, when set and Proxy is empty, routes scraping through
+	// ScraperAPI's proxy endpoint (https://www.scraperapi.com), which rotates
+	// residential IPs and solves Cloudflare challenges.
+	ScraperAPIKey string
+	// ProxyInsecureSkipVerify disables TLS certificate verification for the
+	// proxy. Auto-enabled for ScraperAPI (its proxy mode performs TLS
+	// interception). Only set this for a generic Proxy that requires it.
+	ProxyInsecureSkipVerify bool
+	// Algolia* configure the Untappd search backend, which is powered by
+	// Algolia and is NOT behind Cloudflare (so search needs no proxy). The
+	// defaults are the public search-only credentials embedded in Untappd's web
+	// pages; override via env vars if Untappd ever rotates them.
+	AlgoliaAppID        string `default:"9WBO4RQ3HO"`
+	AlgoliaSearchKey    string `default:"1d347324d67ec472bb7132c66aead485"`
+	AlgoliaBeerIndex    string `default:"beer"`
+	AlgoliaBreweryIndex string `default:"brewery"`
+}
+
+const scraperAPIProxyHost = "proxy-server.scraperapi.com:8001"
+
+// ResolveProxy returns the effective proxy URL for Untappd scraping and whether
+// TLS verification must be skipped. An empty URL means scrape directly.
+func (u Untappd) ResolveProxy() (string, bool) {
+	if u.Proxy != "" {
+		return u.Proxy, u.ProxyInsecureSkipVerify
+	}
+
+	if u.ScraperAPIKey != "" {
+		return "http://scraperapi:" + u.ScraperAPIKey + "@" + scraperAPIProxyHost, true
+	}
+
+	return "", false
 }
 
 type Config struct {

--- a/pkg/integrations/integration.go
+++ b/pkg/integrations/integration.go
@@ -3,6 +3,7 @@ package integrations
 import (
 	"go.uber.org/zap"
 
+	"droscher.com/BeerGargoyle/configs"
 	"droscher.com/BeerGargoyle/pkg/integrations/untappd-web"
 	"droscher.com/BeerGargoyle/pkg/model"
 )
@@ -10,11 +11,31 @@ import (
 type Integration interface {
 	FindBeer(name string) ([]model.Beer, error)
 	FindBrewery(name string) ([]model.Brewery, error)
+	// GetBeerDescription fetches a single beer's long description from its
+	// detail page (used to enrich a beer at save time).
+	GetBeerDescription(externalID uint64) (string, error)
+	// GetBreweryDetails fetches a brewery's description, address and rating from
+	// its detail page (used to enrich a new brewery at save time).
+	GetBreweryDetails(externalID uint64) (model.Brewery, error)
 }
 
-func GetIntegration(name string, logger *zap.Logger) Integration {
+func GetIntegration(name string, config *configs.Config, logger *zap.Logger) Integration {
 	if name == untappdweb.IntegrationName {
-		return untappdweb.NewUntappedWebIntegration(logger)
+		untappd := config.Integrations.Untappd
+		proxyURL, insecureSkipVerify := untappd.ResolveProxy()
+
+		return untappdweb.NewUntappedWebIntegration(logger, untappdweb.Config{
+			Proxy: untappdweb.ProxyConfig{
+				URL:                proxyURL,
+				InsecureSkipVerify: insecureSkipVerify,
+			},
+			Algolia: untappdweb.AlgoliaConfig{
+				AppID:        untappd.AlgoliaAppID,
+				SearchKey:    untappd.AlgoliaSearchKey,
+				BeerIndex:    untappd.AlgoliaBeerIndex,
+				BreweryIndex: untappd.AlgoliaBreweryIndex,
+			},
+		})
 	}
 
 	return nil

--- a/pkg/integrations/untappd-web/algolia.go
+++ b/pkg/integrations/untappd-web/algolia.go
@@ -1,0 +1,134 @@
+package untappdweb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// ErrAlgolia is returned when an Algolia search request fails.
+var ErrAlgolia = errors.New("algolia search request failed")
+
+const algoliaTimeout = 15 * time.Second
+
+// AlgoliaConfig holds the credentials and index names for Untappd's
+// Algolia-backed search. These are public search-only credentials embedded in
+// Untappd's web pages.
+type AlgoliaConfig struct {
+	AppID        string
+	SearchKey    string
+	BeerIndex    string
+	BreweryIndex string
+}
+
+type algoliaClient struct {
+	config AlgoliaConfig
+	client *http.Client
+}
+
+func newAlgoliaClient(config AlgoliaConfig) *algoliaClient {
+	return &algoliaClient{
+		config: config,
+		client: &http.Client{Timeout: algoliaTimeout},
+	}
+}
+
+// algoliaBeerHit maps the fields of an Untappd "beer" index record.
+//
+//nolint:tagliatelle // field names are dictated by Algolia's snake_case API
+type algoliaBeerHit struct {
+	BID          uint64  `json:"bid"`
+	BeerName     string  `json:"beer_name"`
+	BeerABV      float64 `json:"beer_abv"`
+	BeerIBU      float64 `json:"beer_ibu"`
+	BeerLabel    string  `json:"beer_label"`
+	BeerLabelHD  string  `json:"beer_label_hd"`
+	TypeName     string  `json:"type_name"`
+	RatingScore  float64 `json:"rating_score"`
+	Homebrew     int     `json:"homebrew"`
+	BreweryID    uint64  `json:"brewery_id"`
+	BreweryName  string  `json:"brewery_name"`
+	BreweryLabel string  `json:"brewery_label"`
+}
+
+// algoliaBreweryHit maps the fields of an Untappd "brewery" index record.
+//
+//nolint:tagliatelle // field names are dictated by Algolia's snake_case API
+type algoliaBreweryHit struct {
+	BreweryID      uint64 `json:"brewery_id"`
+	BreweryName    string `json:"brewery_name"`
+	BreweryImage   string `json:"brewery_image"`
+	BreweryAddress string `json:"brewery_address"`
+	BreweryCity    string `json:"brewery_city"`
+	BreweryState   string `json:"brewery_state"`
+	BreweryCountry string `json:"brewery_country"`
+}
+
+func (a *algoliaClient) searchBeers(query string) ([]algoliaBeerHit, error) {
+	var response struct {
+		Hits []algoliaBeerHit `json:"hits"`
+	}
+
+	err := a.search(a.config.BeerIndex, query, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Hits, nil
+}
+
+func (a *algoliaClient) searchBreweries(query string) ([]algoliaBreweryHit, error) {
+	var response struct {
+		Hits []algoliaBreweryHit `json:"hits"`
+	}
+
+	err := a.search(a.config.BreweryIndex, query, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Hits, nil
+}
+
+func (a *algoliaClient) search(index, query string, out any) error {
+	body, err := json.Marshal(map[string]string{"params": "query=" + url.QueryEscape(query)})
+	if err != nil {
+		return fmt.Errorf("marshalling algolia request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("https://%s-dsn.algolia.net/1/indexes/%s/query", a.config.AppID, index)
+
+	ctx, cancel := context.WithTimeout(context.Background(), algoliaTimeout)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building algolia request: %w", err)
+	}
+
+	request.Header.Set("X-Algolia-Application-Id", a.config.AppID)
+	request.Header.Set("X-Algolia-Api-Key", a.config.SearchKey)
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := a.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("performing algolia request: %w", err)
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: status %d for index %q", ErrAlgolia, response.StatusCode, index)
+	}
+
+	err = json.NewDecoder(response.Body).Decode(out)
+	if err != nil {
+		return fmt.Errorf("decoding algolia response: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/integrations/untappd-web/beer.go
+++ b/pkg/integrations/untappd-web/beer.go
@@ -2,13 +2,11 @@ package untappdweb
 
 import (
 	"encoding/json"
-	"strconv"
+	"fmt"
 	"strings"
-	"sync"
 
 	"github.com/gocolly/colly/v2"
 	"go.openly.dev/pointy"
-	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
 	"droscher.com/BeerGargoyle/pkg/model"
@@ -22,203 +20,109 @@ const (
 	secChUaFullList   = `"Chromium";v="` + chromeFullVersion + `", "Google Chrome";v="` + chromeFullVersion + `", "Not-A.Brand";v="99.0.0.0"`
 )
 
+// homebrewStylePrefix preserves the original style formatting for homebrews,
+// which Untappd's pages rendered as "Homebrew  |  <style>".
+const homebrewStylePrefix = "Homebrew  |  "
+
+// BeerJSON maps the ld+json embedded in an Untappd beer detail page. Only the
+// description is read; everything else now comes from Algolia search.
 type BeerJSON struct {
 	Description string `json:"description"`
-	Brand       struct {
-		Name string `json:"name"`
-	} `json:"brand"`
-	Image struct {
-		ContentURL string `json:"contentUrl"`
-	} `json:"image"`
-	Sku             uint64 `json:"sku"`
-	AggregateRating struct {
-		RatingValue float64 `json:"ratingValue"`
-		BestRating  string  `json:"bestRating"`
-		ReviewCount int     `json:"reviewCount"`
-	} `json:"aggregateRating"`
 }
 
-type BeerScraped struct {
-	IDLink        string `attr:"href"          selector:"a.label"`
-	Name          string `selector:".name > a"`
-	BreweryIDLink string `attr:"href"          selector:".brewery > a"`
-	Style         string `selector:".style"`
-	ABV           string `selector:".abv"`
-	IBU           string `selector:".ibu"`
-}
-
-type BeerContent struct {
-	Description string `selector:".beer-descrption-read-more"`
-	ImageURL    string `attr:"src"                            selector:"a.label > img"`
-	Rating      string `selector:".details .num"`
-}
-
-type scrapeResults struct {
-	beers []model.Beer
-	err   error
-}
-
+// FindBeer searches Untappd via its Algolia backend, which returns structured
+// JSON and is not behind Cloudflare, so it requires no proxy.
 func (u *UntappedWebIntegration) FindBeer(name string) ([]model.Beer, error) {
-	collector := colly.NewCollector(
-		colly.AllowedDomains("untappd.com"),
-		colly.UserAgent(userAgent),
-	)
+	u.logger.Info("searching untappd beers", zap.String("query", name))
 
-	setBrowserHeaders(collector)
+	hits, err := u.algolia.searchBeers(name)
+	if err != nil {
+		return nil, err
+	}
 
-	var (
-		errs         error
-		results      []model.Beer
-		scrapedPages []BeerScraped
-	)
+	results := make([]model.Beer, 0, len(hits))
+	for _, hit := range hits {
+		results = append(results, beerFromHit(hit))
+	}
 
-	breweries := make(map[string]model.Brewery, 0)
+	u.logger.Info("finished untappd beer search", zap.String("query", name), zap.Int("results", len(results)))
 
-	collector.OnHTML(".beer-item", func(element *colly.HTMLElement) {
-		scraped := BeerScraped{}
+	return results, nil
+}
 
-		err := element.Unmarshal(&scraped)
-		if multierr.AppendInto(&errs, err) {
-			u.logger.Error("failed to unmarshal scraped beer", zap.Error(err))
+func beerFromHit(hit algoliaBeerHit) model.Beer {
+	beer := model.Beer{
+		Name:           hit.BeerName,
+		ImageURL:       firstNonEmpty(hit.BeerLabelHD, hit.BeerLabel),
+		Style:          model.BeerStyle{Name: styleName(hit)},
+		ExternalSource: pointy.String(IntegrationName),
+		ExternalID:     pointy.Uint64(hit.BID),
+		Brewery: model.Brewery{
+			Name:           hit.BreweryName,
+			ImageURL:       hit.BreweryLabel,
+			ExternalSource: pointy.String(IntegrationName),
+			ExternalID:     pointy.Uint64(hit.BreweryID),
+		},
+	}
 
-			return
-		}
+	if hit.BeerABV > 0 {
+		beer.ABV = pointy.Float64(hit.BeerABV)
+	}
 
-		idString := scraped.IDLink[strings.LastIndex(scraped.IDLink, "/")+1:]
+	if hit.BeerIBU > 0 {
+		beer.IBU = pointy.Uint64(uint64(hit.BeerIBU))
+	}
 
-		u.logger.Info("successfully scraped item from results", zap.String("id", idString), zap.String("name", scraped.Name))
+	if hit.RatingScore > 0 {
+		beer.ExternalRating = pointy.Float64(hit.RatingScore)
+	}
 
-		if _, found := breweries[scraped.BreweryIDLink]; !found {
-			err = u.cacheBreweryDetails(scraped.BreweryIDLink, collector, breweries)
-			if multierr.AppendInto(&errs, err) {
-				return
-			}
-		}
+	return beer
+}
 
-		scrapedPages = append(scrapedPages, scraped)
-	})
+func styleName(hit algoliaBeerHit) string {
+	if hit.Homebrew == 1 {
+		return homebrewStylePrefix + hit.TypeName
+	}
 
+	return hit.TypeName
+}
+
+// GetBeerDescription fetches a single beer's long description from its Untappd
+// detail page. The page is behind Cloudflare, so this goes through the
+// configured proxy when running from a datacenter IP.
+func (u *UntappedWebIntegration) GetBeerDescription(externalID uint64) (string, error) {
+	collector := u.newCollector()
 	u.registerDebugHandlers(collector)
 
-	u.logger.Info("scraping query results", zap.String("query", name))
-	multierr.AppendInto(&errs, collector.Visit("https://untappd.com/search?q=/"+name))
+	var description string
 
-	results = make([]model.Beer, 0, len(scrapedPages))
-
-	var beerWG sync.WaitGroup
-
-	beerChan := make(chan scrapeResults, len(scrapedPages))
-
-	for _, scraped := range scrapedPages {
-		beerWG.Add(1)
-
-		go func() {
-			defer beerWG.Done()
-			u.getBeerData(collector.Clone(), scraped, breweries, beerChan)
-		}()
-	}
-
-	beerWG.Wait()
-
-	for range scrapedPages {
-		result := <-beerChan
-		results = append(results, result.beers...)
-		multierr.AppendInto(&errs, result.err)
-	}
-
-	u.logger.Info("finished scraping query results", zap.Any("results", results), zap.Error(errs))
-
-	return results, errs
-}
-
-func (u *UntappedWebIntegration) getBeerData(detailCollector *colly.Collector, scraped BeerScraped, breweries map[string]model.Brewery, beerChan chan scrapeResults) {
-	setBrowserHeaders(detailCollector)
-	u.registerDebugHandlers(detailCollector)
-
-	beer := model.Beer{
-		Name:           scraped.Name,
-		ExternalSource: pointy.String(IntegrationName),
-		Brewery:        breweries[scraped.BreweryIDLink],
-		Style:          model.BeerStyle{Name: scraped.Style},
-		ABV:            extractABV(scraped),
-		IBU:            extractIBU(scraped),
-	}
-
-	detailCollector.OnHTML("head script[type='application/ld+json']", func(element *colly.HTMLElement) {
+	collector.OnHTML("head script[type='application/ld+json']", func(element *colly.HTMLElement) {
 		var beerJSON BeerJSON
-		_ = json.Unmarshal([]byte(element.Text), &beerJSON)
 
-		u.logger.Info("successfully scraped beer from JSON data", zap.Uint64("id", beerJSON.Sku), zap.String("description", beerJSON.Description))
-
-		beer.Description = beerJSON.Description
-		if !strings.HasPrefix(beerJSON.Image.ContentURL, "https://next.untappd.com/og/") {
-			beer.ImageURL = beerJSON.Image.ContentURL
-		}
-		beer.ExternalID = pointy.Uint64(beerJSON.Sku)
-		beer.ExternalRating = pointy.Float64(beerJSON.AggregateRating.RatingValue)
-	})
-
-	detailCollector.OnHTML(".content", func(element *colly.HTMLElement) {
-		beerContent := BeerContent{}
-
-		err := element.Unmarshal(&beerContent)
+		err := json.Unmarshal([]byte(element.Text), &beerJSON)
 		if err != nil {
 			return
 		}
 
-		if len(beer.Description) == 0 {
-			beer.Description = beerContent.Description
-		}
-
-		if len(beer.ImageURL) == 0 {
-			beer.ImageURL = beerContent.ImageURL
-		}
-
-		if beer.ExternalRating == nil {
-			rating, err := strconv.ParseFloat(beerContent.Rating, 64)
-			if err == nil {
-				beer.ExternalRating = pointy.Float64(rating)
-			}
+		if beerJSON.Description != "" {
+			description = beerJSON.Description
 		}
 	})
 
-	idString := scraped.IDLink[strings.LastIndex(scraped.IDLink, "/")+1:]
-	u.logger.Info("scraping beer page", zap.String("id", idString))
+	err := collector.Visit(fmt.Sprintf("https://untappd.com/beer/%d", externalID))
 
-	err := detailCollector.Visit("https://untappd.com/beer/" + idString)
-	if err == nil && beer.ExternalID == nil {
-		externalID, err := strconv.ParseUint(idString, 10, 64)
-		if err == nil {
-			beer.ExternalID = pointy.Uint64(externalID)
+	return description, err
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
 		}
 	}
 
-	beerChan <- scrapeResults{beers: []model.Beer{beer}, err: err}
-}
-
-func (u *UntappedWebIntegration) cacheBreweryDetails(breweryURI string, collector *colly.Collector, breweries map[string]model.Brewery) error {
-	clone := collector.Clone()
-	setBrowserHeaders(clone)
-	u.registerDebugHandlers(clone)
-
-	brewery, err := u.getBreweryFromURI(breweryURI, clone)
-	if err != nil {
-		return err
-	}
-
-	breweries[breweryURI] = brewery
-
-	return nil
-}
-
-func extractABV(details BeerScraped) *float64 {
-	if strings.Contains(details.ABV, "%") {
-		abv, _ := strconv.ParseFloat(details.ABV[:strings.Index(details.ABV, "%")], 64) //nolint: gocritic // We know we won't get -1
-
-		return &abv
-	}
-
-	return nil
+	return ""
 }
 
 func (u *UntappedWebIntegration) registerDebugHandlers(collector *colly.Collector) {
@@ -244,7 +148,7 @@ func (u *UntappedWebIntegration) registerDebugHandlers(collector *colly.Collecto
 			}
 			fields = append(fields, zap.String("resp_body_snippet", string(runes)))
 		}
-		u.logger.Error("error while scraping beer search results", fields...)
+		u.logger.Error("error while scraping beer detail page", fields...)
 	})
 }
 
@@ -277,14 +181,4 @@ func setBrowserHeaders(collector *colly.Collector) {
 		req.Headers.Set("Sec-Fetch-User", "?1")
 		req.Headers.Set("Upgrade-Insecure-Requests", "1")
 	})
-}
-
-func extractIBU(details BeerScraped) *uint64 {
-	if !strings.HasPrefix(details.IBU, "N/A") {
-		ibu, _ := strconv.ParseUint(strings.Split(details.IBU, " ")[0], 0, 64)
-
-		return pointy.Uint64(ibu)
-	}
-
-	return nil
 }

--- a/pkg/integrations/untappd-web/beer_test.go
+++ b/pkg/integrations/untappd-web/beer_test.go
@@ -1,6 +1,7 @@
 package untappdweb_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,45 +11,68 @@ import (
 	. "droscher.com/BeerGargoyle/pkg/integrations/untappd-web"
 )
 
-func TestFindBeer(t *testing.T) {
-	untappd := NewUntappedWebIntegration(zaptest.NewLogger(t))
-	results, err := untappd.FindBeer("Twin Sails Lights Out (2021)")
-	require.NoError(t, err)
-	assert.Len(t, results, 1)
+// testConfig returns an integration configured with the public Algolia search
+// credentials and no proxy (search is not behind Cloudflare).
+func testConfig() Config {
+	return Config{
+		Algolia: AlgoliaConfig{
+			AppID:        "9WBO4RQ3HO",
+			SearchKey:    "1d347324d67ec472bb7132c66aead485",
+			BeerIndex:    "beer",
+			BreweryIndex: "brewery",
+		},
+	}
+}
 
-	assert.Equal(t, "Lights Out (2021)", results[0].Name)
-	assert.InDelta(t, 14.3, *results[0].ABV, 0.01)
-	assert.Nil(t, results[0].IBU)
-	assert.Equal(t, "Stout - Imperial / Double", results[0].Style.Name)
-	assert.Contains(t, results[0].Description, "toasted coconut")
-	assert.NotEmpty(t, results[0].ImageURL)
-	assert.Equal(t, "Twin Sails Brewing", results[0].Brewery.Name)
-	assert.Equal(t, "We're just a bunch of people who love beer that took a stab at this brewery thing. People take beer too seriously, we decided to do things differently.", results[0].Brewery.Description)
-	assert.NotEmpty(t, results[0].Brewery.ImageURL)
-	assert.Equal(t, "Port Moody Canada", results[0].Brewery.Address.Locality)
-	assert.NotNil(t, results[0].Brewery.Address.Region)
-	assert.Equal(t, "BC", *results[0].Brewery.Address.Region)
-	assert.NotNil(t, results[0].Brewery.Address.StreetAddress)
-	assert.Equal(t, "2821 Murray St", *results[0].Brewery.Address.StreetAddress)
-	assert.Equal(t, IntegrationName, *results[0].ExternalSource)
-	assert.Equal(t, uint64(4591477), *results[0].ExternalID)
-	assert.Greater(t, *results[0].ExternalRating, 0.0)
+func TestFindBeer(t *testing.T) {
+	untappd := NewUntappedWebIntegration(zaptest.NewLogger(t), testConfig())
+	results, err := untappd.FindBeer("Twin Sails Lights Out")
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+
+	beer := results[0]
+	assert.Contains(t, beer.Name, "Lights Out")
+	assert.NotNil(t, beer.ABV)
+	assert.Positive(t, *beer.ABV)
+	assert.NotEmpty(t, beer.Style.Name)
+	assert.NotEmpty(t, beer.ImageURL)
+	assert.Equal(t, "Twin Sails Brewing", beer.Brewery.Name)
+	assert.NotNil(t, beer.Brewery.ExternalID)
+	assert.Equal(t, IntegrationName, *beer.ExternalSource)
+	assert.NotNil(t, beer.ExternalID)
+	assert.NotNil(t, beer.ExternalRating)
+	assert.Positive(t, *beer.ExternalRating)
+}
+
+// TestGetBeerDescription exercises the Cloudflare-gated detail-page fetch. It is
+// skipped when the request is blocked (e.g. from a datacenter IP in CI without a
+// proxy), since the description is only available behind Cloudflare.
+func TestGetBeerDescription(t *testing.T) {
+	untappd := NewUntappedWebIntegration(zaptest.NewLogger(t), testConfig())
+
+	results, err := untappd.FindBeer("Twin Sails Lights Out")
+	require.NoError(t, err)
+	require.NotEmpty(t, results)
+	require.NotNil(t, results[0].ExternalID)
+
+	description, err := untappd.GetBeerDescription(*results[0].ExternalID)
+	if err != nil || description == "" {
+		t.Skipf("beer detail page unavailable (likely Cloudflare): err=%v", err)
+	}
+
+	assert.NotEmpty(t, description)
 }
 
 func TestFindHomebrew(t *testing.T) {
-	untappd := NewUntappedWebIntegration(zaptest.NewLogger(t))
+	untappd := NewUntappedWebIntegration(zaptest.NewLogger(t), testConfig())
 	results, err := untappd.FindBeer("Paronomastic Precious Bet")
 	require.NoError(t, err)
-	assert.Len(t, results, 1)
+	require.NotEmpty(t, results)
 
-	assert.Equal(t, "Precious Bet", results[0].Name)
-	assert.InDelta(t, 8.2, *results[0].ABV, 0.01)
-	assert.Equal(t, uint64(18), *results[0].IBU)
-	assert.Equal(t, "Homebrew \u00a0|\u00a0 Farmhouse Ale - Saison", results[0].Style.Name)
-	assert.Equal(t, "Saison aged on peaches ‘n Brett.", results[0].Description)
-	assert.NotEmpty(t, results[0].ImageURL)
-	assert.Equal(t, "Paronomastic Brewing", results[0].Brewery.Name)
-	assert.Equal(t, IntegrationName, *results[0].ExternalSource)
-	assert.Equal(t, uint64(4557393), *results[0].ExternalID)
-	assert.Nil(t, results[0].ExternalRating)
+	beer := results[0]
+	assert.Contains(t, beer.Name, "Precious Bet")
+	assert.True(t, strings.HasPrefix(beer.Style.Name, "Homebrew"), "homebrew style should be prefixed: %q", beer.Style.Name)
+	assert.Equal(t, "Paronomastic Brewing", beer.Brewery.Name)
+	assert.Equal(t, IntegrationName, *beer.ExternalSource)
+	assert.NotNil(t, beer.ExternalID)
 }

--- a/pkg/integrations/untappd-web/brewery.go
+++ b/pkg/integrations/untappd-web/brewery.go
@@ -32,35 +32,47 @@ type BreweryJSON struct {
 	} `json:"address"`
 }
 
+// FindBrewery searches Untappd's Algolia "brewery" index, which returns
+// structured JSON and is not behind Cloudflare, so it requires no proxy.
 func (u *UntappedWebIntegration) FindBrewery(name string) ([]model.Brewery, error) {
-	collector := colly.NewCollector(
-		colly.AllowedDomains("untappd.com"),
-	)
+	u.logger.Info("searching untappd breweries", zap.String("query", name))
 
-	var (
-		errs    error
-		results []model.Brewery
-	)
+	hits, err := u.algolia.searchBreweries(name)
+	if err != nil {
+		return nil, err
+	}
 
-	collector.OnHTML(".beer-item", func(element *colly.HTMLElement) {
-		ratingString := element.ChildAttr(".rating > div.caps", "data-rating")
-		rating, _ := strconv.ParseFloat(ratingString, 64)
+	results := make([]model.Brewery, 0, len(hits))
+	for _, hit := range hits {
+		results = append(results, breweryFromHit(hit))
+	}
 
-		if rating > 0.0 {
-			breweryURI := element.ChildAttr(".name > a", "href")
+	return results, nil
+}
 
-			brewery, err := u.getBreweryFromURI(breweryURI, collector)
-			if multierr.AppendInto(&errs, err) {
-				return
-			}
+func breweryFromHit(hit algoliaBreweryHit) model.Brewery {
+	return model.Brewery{
+		Name:     hit.BreweryName,
+		ImageURL: hit.BreweryImage,
+		Address: model.Address{
+			Country:       hit.BreweryCountry,
+			Locality:      hit.BreweryCity,
+			Region:        stringPointer(hit.BreweryState),
+			StreetAddress: stringPointer(hit.BreweryAddress),
+		},
+		ExternalSource: pointy.String(IntegrationName),
+		ExternalID:     pointy.Uint64(hit.BreweryID),
+	}
+}
 
-			results = append(results, brewery)
-		}
-	})
+// GetBreweryDetails fetches a brewery's description, address and rating from its
+// Untappd page (behind Cloudflare, so routed through the configured proxy). Used
+// to enrich a brewery when a beer is first saved.
+func (u *UntappedWebIntegration) GetBreweryDetails(externalID uint64) (model.Brewery, error) {
+	collector := u.newCollector()
+	u.registerDebugHandlers(collector)
 
-	multierr.AppendInto(&errs, collector.Visit("https://untappd.com/search?q=/"+name+"&type=brewery"))
-
-	return results, errs
+	return u.getBreweryFromURI("brewery/"+strconv.FormatUint(externalID, 10), collector)
 }
 
 func (u *UntappedWebIntegration) getBreweryFromURI(uri string, collector *colly.Collector) (model.Brewery, error) {
@@ -89,27 +101,11 @@ func (u *UntappedWebIntegration) getBreweryFromURI(uri string, collector *colly.
 	})
 
 	collector.OnHTML("p.rss a", func(element *colly.HTMLElement) {
-		idLink := element.Attr("href")
-		idString := idLink[strings.LastIndex(idLink, "/")+1:]
-
-		id, err := strconv.ParseUint(idString, 10, 64)
-		if err != nil {
-			u.logger.Error("failed to parse brewery id", zap.String("url", idLink), zap.Error(err))
-		} else {
-			breweryID = id
-		}
+		breweryID = parseTrailingID(u.logger, element.Attr("href"))
 	})
 
 	collector.OnHTML("head meta[property='og:url']", func(element *colly.HTMLElement) {
-		breweryURI := element.Attr("content")
-		idString := breweryURI[strings.LastIndex(breweryURI, "/")+1:]
-
-		id, err := strconv.ParseUint(idString, 10, 64)
-		if err != nil {
-			u.logger.Error("failed to parse brewery id", zap.String("url", breweryURI), zap.Error(err))
-		} else {
-			breweryID = id
-		}
+		breweryID = parseTrailingID(u.logger, element.Attr("content"))
 	})
 
 	multierr.AppendInto(&errs, collector.Visit("https://untappd.com/"+uri))
@@ -119,6 +115,19 @@ func (u *UntappedWebIntegration) getBreweryFromURI(uri string, collector *colly.
 	}
 
 	return brewery, errs
+}
+
+func parseTrailingID(logger *zap.Logger, link string) uint64 {
+	idString := link[strings.LastIndex(link, "/")+1:]
+
+	id, err := strconv.ParseUint(idString, 10, 64)
+	if err != nil {
+		logger.Error("failed to parse brewery id", zap.String("url", link), zap.Error(err))
+
+		return 0
+	}
+
+	return id
 }
 
 func stringPointer(value string) *string {

--- a/pkg/integrations/untappd-web/brewery_test.go
+++ b/pkg/integrations/untappd-web/brewery_test.go
@@ -11,20 +11,36 @@ import (
 )
 
 func TestFindBrewery(t *testing.T) {
-	untappd := NewUntappedWebIntegration(zaptest.NewLogger(t))
+	untappd := NewUntappedWebIntegration(zaptest.NewLogger(t), testConfig())
 	results, err := untappd.FindBrewery("Fremont Brewing")
 
 	require.NoError(t, err)
-	assert.Len(t, results, 1)
-	assert.Equal(t, "Fremont Brewing", results[0].Name)
-	assert.Equal(t, "Fremont Brewing was born of our love for our home and history as well as the desire to prove that beer made with the finest local ingredients – organic when possible --, is not the wave of the future but the doorway to beer's history. Starting a brewery in the midst of the Great Recession is clearly an act of passion. We invite you to come along with us and enjoy that passion -- because beer matters.", results[0].Description)
-	assert.NotEmpty(t, results[0].ImageURL)
-	assert.Equal(t, IntegrationName, *results[0].ExternalSource)
-	assert.Equal(t, uint64(1508), *results[0].ExternalID)
-	assert.InDelta(t, 4.038, *results[0].ExternalRating, 0.1)
-	assert.Equal(t, "Seattle", results[0].Address.Locality)
-	assert.NotNil(t, results[0].Address.Region)
-	assert.Equal(t, "WA", *results[0].Address.Region)
-	assert.NotNil(t, results[0].Address.StreetAddress)
-	assert.Equal(t, "3409 Woodland Park Ave North", *results[0].Address.StreetAddress)
+	require.NotEmpty(t, results)
+
+	brewery := results[0]
+	assert.Equal(t, "Fremont Brewing", brewery.Name)
+	assert.NotEmpty(t, brewery.ImageURL)
+	assert.Equal(t, IntegrationName, *brewery.ExternalSource)
+	assert.Equal(t, uint64(1508), *brewery.ExternalID)
+	assert.Equal(t, "Seattle", brewery.Address.Locality)
+	assert.NotNil(t, brewery.Address.Region)
+	assert.Equal(t, "WA", *brewery.Address.Region)
+	assert.NotNil(t, brewery.Address.StreetAddress)
+	assert.Equal(t, "3409 Woodland Park Ave North", *brewery.Address.StreetAddress)
+}
+
+// TestGetBreweryDetails exercises the Cloudflare-gated detail-page fetch. It is
+// skipped when the request is blocked (e.g. from a datacenter IP in CI without a
+// proxy), since the description is only available behind Cloudflare.
+func TestGetBreweryDetails(t *testing.T) {
+	untappd := NewUntappedWebIntegration(zaptest.NewLogger(t), testConfig())
+
+	brewery, err := untappd.GetBreweryDetails(1508)
+	if err != nil || brewery.Name == "" {
+		t.Skipf("brewery detail page unavailable (likely Cloudflare): err=%v", err)
+	}
+
+	assert.Equal(t, "Fremont Brewing", brewery.Name)
+	assert.NotEmpty(t, brewery.Description)
+	assert.NotNil(t, brewery.ExternalRating)
 }

--- a/pkg/integrations/untappd-web/untappd-web-integration.go
+++ b/pkg/integrations/untappd-web/untappd-web-integration.go
@@ -1,13 +1,85 @@
 package untappdweb
 
-import "go.uber.org/zap"
+import (
+	"crypto/tls"
+	"net/http"
+	"net/url"
+
+	"github.com/gocolly/colly/v2"
+	"go.uber.org/zap"
+)
 
 const IntegrationName = "untappd_web"
 
-type UntappedWebIntegration struct {
-	logger *zap.Logger
+// ProxyConfig configures an optional outbound proxy for detail-page requests,
+// used to bypass Cloudflare challenges served to datacenter IPs.
+type ProxyConfig struct {
+	URL                string
+	InsecureSkipVerify bool
 }
 
-func NewUntappedWebIntegration(logger *zap.Logger) *UntappedWebIntegration {
-	return &UntappedWebIntegration{logger: logger}
+// Config bundles everything the integration needs: Algolia search (no proxy
+// required) and an optional proxy for Cloudflare-gated detail pages.
+type Config struct {
+	Proxy   ProxyConfig
+	Algolia AlgoliaConfig
+}
+
+type UntappedWebIntegration struct {
+	logger  *zap.Logger
+	proxy   ProxyConfig
+	algolia *algoliaClient
+}
+
+func NewUntappedWebIntegration(logger *zap.Logger, config Config) *UntappedWebIntegration {
+	return &UntappedWebIntegration{
+		logger:  logger,
+		proxy:   config.Proxy,
+		algolia: newAlgoliaClient(config.Algolia),
+	}
+}
+
+// newCollector builds a collector with browser headers and the configured proxy
+// applied. The proxy is set on this parent collector before any clones are made
+// so that clones (which share colly's backend) inherit the transport.
+func (u *UntappedWebIntegration) newCollector() *colly.Collector {
+	collector := colly.NewCollector(
+		colly.AllowedDomains("untappd.com"),
+		colly.UserAgent(userAgent),
+	)
+
+	setBrowserHeaders(collector)
+	u.applyProxy(collector)
+
+	return collector
+}
+
+// applyProxy installs the configured proxy transport on the collector. It must
+// be called on the parent collector before any clones or requests are made:
+// colly's Clone() shares the underlying backend, so clones inherit the
+// transport and setting it later from concurrent goroutines would race.
+func (u *UntappedWebIntegration) applyProxy(collector *colly.Collector) {
+	if u.proxy.URL == "" {
+		return
+	}
+
+	proxyURL, err := url.Parse(u.proxy.URL)
+	if err != nil {
+		u.logger.Error("invalid untappd proxy URL; scraping without proxy", zap.Error(err))
+
+		return
+	}
+
+	transport := &http.Transport{
+		Proxy:             http.ProxyURL(proxyURL),
+		DisableKeepAlives: true,
+	}
+
+	if u.proxy.InsecureSkipVerify {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // proxy (e.g. ScraperAPI) performs TLS interception
+	}
+
+	collector.WithTransport(transport)
+
+	u.logger.Info("untappd scraping via proxy", zap.String("proxy_host", proxyURL.Host))
 }

--- a/pkg/server/beer.go
+++ b/pkg/server/beer.go
@@ -31,7 +31,7 @@ func (b *BeerServer) FindBeer(_ context.Context, request *connect.Request[api.Fi
 	var beers []*api.Beer
 
 	for _, integration := range b.config.Integrations.Beer {
-		beerIntegration := integrations.GetIntegration(integration, b.logger)
+		beerIntegration := integrations.GetIntegration(integration, b.config, b.logger)
 
 		foundBeers, err := beerIntegration.FindBeer(request.Msg.GetQuery())
 		if err != nil {
@@ -65,6 +65,8 @@ func (b *BeerServer) AddBeer(ctx context.Context, request *connect.Request[api.A
 			return nil, err
 		}
 	}
+
+	b.enrichBeerDescription(&beer)
 
 	newBeer, err := b.repository.AddBeer(ctx, beer)
 	if err != nil {
@@ -107,8 +109,67 @@ func (b *BeerServer) loadBrewery(ctx context.Context, pbBrewery *api.Brewery, be
 		}
 
 		beer.Brewery = grpc.BreweryToModel(pbBrewery)
+		b.enrichBrewery(&beer.Brewery)
 	} else {
 		beer.BreweryID = brewery.ID
+	}
+}
+
+// enrichBeerDescription fills in a beer's long description from the source
+// integration's detail page when it is missing. Search results no longer carry
+// descriptions (they come from Algolia), so this runs at save time only.
+func (b *BeerServer) enrichBeerDescription(beer *model.Beer) {
+	if beer.ExternalSource == nil || beer.ExternalID == nil || beer.Description != "" {
+		return
+	}
+
+	integration := integrations.GetIntegration(*beer.ExternalSource, b.config, b.logger)
+	if integration == nil {
+		return
+	}
+
+	description, err := integration.GetBeerDescription(*beer.ExternalID)
+	if err != nil {
+		b.logger.Error("failed to fetch beer description for save", zap.Uint64("external_id", *beer.ExternalID), zap.Error(err))
+
+		return
+	}
+
+	beer.Description = description
+}
+
+// enrichBrewery fills in a new brewery's description, address and rating from
+// the source integration's detail page. Only called for breweries not already
+// in the database.
+func (b *BeerServer) enrichBrewery(brewery *model.Brewery) {
+	if brewery.ExternalSource == nil || brewery.ExternalID == nil || brewery.Description != "" {
+		return
+	}
+
+	integration := integrations.GetIntegration(*brewery.ExternalSource, b.config, b.logger)
+	if integration == nil {
+		return
+	}
+
+	details, err := integration.GetBreweryDetails(*brewery.ExternalID)
+	if err != nil {
+		b.logger.Error("failed to fetch brewery details for save", zap.Uint64("external_id", *brewery.ExternalID), zap.Error(err))
+
+		return
+	}
+
+	brewery.Description = details.Description
+
+	if details.ExternalRating != nil {
+		brewery.ExternalRating = details.ExternalRating
+	}
+
+	if brewery.Address.StreetAddress == nil && brewery.Address.Locality == "" {
+		brewery.Address = details.Address
+	}
+
+	if brewery.ImageURL == "" {
+		brewery.ImageURL = details.ImageURL
 	}
 }
 


### PR DESCRIPTION
Couple of issues with Untappd integration. They changed their search and there's cloudflare protection over retrieving pages. This PR adds support for using the new Algolia backend for search results and adds config for a proxy that bypasses cloudflare, needed just for beer/brewery description retrieval.